### PR TITLE
Don't create a big FileInfo object just to get the image file extension

### DIFF
--- a/EPPlus/Drawing/ExcelPicture.cs
+++ b/EPPlus/Drawing/ExcelPicture.cs
@@ -59,8 +59,7 @@ namespace OfficeOpenXml.Drawing
                 UriPic = UriHelper.ResolvePartUri(drawings.UriDrawing, RelPic.TargetUri);
 
                 Part = drawings.Part.Package.GetPart(UriPic);
-                FileInfo f = new FileInfo(UriPic.OriginalString);
-                ContentType = GetContentType(f.Extension);
+                ContentType = Path.GetExtension(UriPic.OriginalString);
                 _image = Image.FromStream(Part.GetStream());
 
 #if (Core)


### PR DESCRIPTION
#242 FileInfo class is not permitted in AppDomain's that don't have code-level permission to access the file system.  In this case, we are just looking for the image's file extension, and we can use the Path.GetExtension method which just parses the string to do this, instead of actually creating an instance of the FileInfo object.